### PR TITLE
Catch errors when Decision does not exits

### DIFF
--- a/dist/execute-decision.js
+++ b/dist/execute-decision.js
@@ -13,7 +13,12 @@ function executeDecision(params, processResponse) {
   const context = params.context;
   const decisionName = params.decisionName;
 
-  const decision = getDecisionInLatestVersion(decisionName);
+  let decision;
+  try {
+    decision = getDecisionInLatestVersion(decisionName);
+  } catch (e) {
+    logger.warn(e)
+  }
   if (decision === undefined) {
     const errorMessage = `Decision ${decisionName} was not found.`;
     logger.info(errorMessage);


### PR DESCRIPTION
When executing a decision that does not exists decision-inmemory-store throws an error, however execute decision expects the decision variable to be empty which causes an unhandled error and programs exists.